### PR TITLE
Workaround for macOS TISGetInputSourceProperty crash

### DIFF
--- a/src/macos/keycodes.rs
+++ b/src/macos/keycodes.rs
@@ -53,3 +53,57 @@ pub const kVK_LeftArrow: u16 = 0x7B;
 pub const kVK_RightArrow: u16 = 0x7C;
 pub const kVK_DownArrow: u16 = 0x7D;
 pub const kVK_UpArrow: u16 = 0x7E;
+
+// US-ANSI Keyboard Layout
+// From: https://github.com/socsieng/sendkeys/blob/main/Sources/SendKeysLib/KeyCodes.swift
+pub mod us_ansi {
+    pub const a: u16 = 0x00;
+    pub const b: u16 = 0x0B;
+    pub const c: u16 = 0x08;
+    pub const d: u16 = 0x02;
+    pub const e: u16 = 0x0E;
+    pub const f: u16 = 0x03;
+    pub const g: u16 = 0x05;
+    pub const h: u16 = 0x04;
+    pub const i: u16 = 0x22;
+    pub const j: u16 = 0x26;
+    pub const k: u16 = 0x28;
+    pub const l: u16 = 0x25;
+    pub const m: u16 = 0x2E;
+    pub const n: u16 = 0x2D;
+    pub const o: u16 = 0x1F;
+    pub const p: u16 = 0x23;
+    pub const q: u16 = 0x0C;
+    pub const r: u16 = 0x0F;
+    pub const s: u16 = 0x01;
+    pub const t: u16 = 0x11;
+    pub const u: u16 = 0x20;
+    pub const v: u16 = 0x09;
+    pub const w: u16 = 0x0D;
+    pub const x: u16 = 0x07;
+    pub const y: u16 = 0x10;
+    pub const z: u16 = 0x06;
+
+    pub const zero: u16 = 0x1D;
+    pub const one: u16 = 0x12;
+    pub const two: u16 = 0x13;
+    pub const three: u16 = 0x14;
+    pub const four: u16 = 0x15;
+    pub const five: u16 = 0x17;
+    pub const six: u16 = 0x16;
+    pub const seven: u16 = 0x1A;
+    pub const eight: u16 = 0x1C;
+    pub const nine: u16 = 0x19;
+
+    pub const equals: u16 = 0x18;
+    pub const minus: u16 = 0x1B;
+    pub const semicolon: u16 = 0x29;
+    pub const apostrophe: u16 = 0x27;
+    pub const comma: u16 = 0x2B;
+    pub const period: u16 = 0x2F;
+    pub const forwardSlash: u16 = 0x2C;
+    pub const backslash: u16 = 0x2A;
+    pub const grave: u16 = 0x32;
+    pub const leftBracket: u16 = 0x21;
+    pub const rightBracket: u16 = 0x1E;
+}

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -467,9 +467,65 @@ impl Enigo {
             Key::Tab => kVK_Tab,
             Key::UpArrow => kVK_UpArrow,
             Key::Raw(raw_keycode) => raw_keycode,
-            Key::Layout(c) => self.get_layoutdependent_keycode(c.to_string()),
+
+            // Workaround until https://github.com/enigo-rs/enigo/issues/153 is fixed
+            // Key::Layout(c) => self.get_layoutdependent_keycode(c.to_string()),
+            Key::Layout(c) => self.get_us_ansi_keycode(c),
 
             Key::Super | Key::Command | Key::Windows | Key::Meta => kVK_Command,
+        }
+    }
+
+    fn get_us_ansi_keycode(&self, char: Char) -> CGKeyCode {
+        use us_ansi::*;
+        match char {
+            'a' => a,
+            'b' => b,
+            'c' => c,
+            'd' => d,
+            'e' => e,
+            'f' => f,
+            'g' => g,
+            'h' => h,
+            'i' => i,
+            'j' => j,
+            'k' => k,
+            'l' => l,
+            'm' => m,
+            'n' => n,
+            'o' => o,
+            'p' => p,
+            'q' => q,
+            'r' => r,
+            's' => s,
+            't' => t,
+            'u' => u,
+            'v' => v,
+            'w' => w,
+            'x' => x,
+            'y' => y,
+            'z' => z,
+            '0' => zero,
+            '1' => one,
+            '2' => two,
+            '3' => three,
+            '4' => four,
+            '5' => five,
+            '6' => six,
+            '7' => seven,
+            '8' => eight,
+            '9' => nine,
+            '=' => equals,
+            '-' => minus,
+            ';' => semicolon,
+            '\'' => apostrophe,
+            ',' => comma,
+            '.' => period,
+            '/' => forwardSlash,
+            '\\' => backslash,
+            '`' => grave,
+            '[' => leftBracket,
+            ']' => rightBracket,
         }
     }
 

--- a/src/macos/macos_impl.rs
+++ b/src/macos/macos_impl.rs
@@ -476,9 +476,9 @@ impl Enigo {
         }
     }
 
-    fn get_us_ansi_keycode(&self, char: Char) -> CGKeyCode {
+    fn get_us_ansi_keycode(&self, key: char) -> CGKeyCode {
         use us_ansi::*;
-        match char {
+        match key {
             'a' => a,
             'b' => b,
             'c' => c,
@@ -526,6 +526,7 @@ impl Enigo {
             '`' => grave,
             '[' => leftBracket,
             ']' => rightBracket,
+            _ => 0,
         }
     }
 


### PR DESCRIPTION
`TISGetInputSourceProperty` crashes when running in an https://github.com/iced-rs/iced application. 

Presumably related to https://github.com/enigo-rs/enigo/issues/153, with the exact symptom but concerns https://github.com/tauri-apps/tauri, another GUI library.

Workaround is to skip the keyboard layout check and always assume a US-ANSI layout.